### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@ certifi==2020.6.20
 certstream==1.11
 chardet==3.0.4
 idna==2.10
-pkg-resources==0.0.0
 PyYAML==5.3.1
 requests==2.24.0
 six==1.15.0
 termcolor==1.1.0
+testresources==2.0.1
 urllib3==1.25.10
 websocket-client==0.57.0


### PR DESCRIPTION
pkg-resource==0.0.0 was triggering an error 

```
Could not find a version that satisfies the requirement pkg-resources==0.0.0
```
The reason and further details of the issue is listed here  [Pip Freeze](https://github.com/pypa/pip/issues/4022) , following several stackoverflow answers removing it from the requirements.txt cleared the problem . Testrources was added to the list since launchpadlib 1.10.13 requires testresources.