### PR TITLE
Update certstream package to newer version to fix connection issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 certifi==2020.6.20
-certstream==1.10
+certstream==1.11
 chardet==3.0.4
 idna==2.10
 PyYAML==5.3.1


### PR DESCRIPTION
certstream 1.10 had an issue that causes the script to return the following error every other minute:
`Error connecting to CertStream - Connection is already closed. - Sleeping for a few seconds and trying again...`

This has been addressed in version 1.11 as documented [here](https://github.com/CaliDog/certstream-python/issues/27)